### PR TITLE
Fix mask expressions with multiple ranges

### DIFF
--- a/AmberMdPrep.sh
+++ b/AmberMdPrep.sh
@@ -595,12 +595,12 @@ while read MLINE ; do
     if [ -z "$HEAVYMASK" ] ; then
       HEAVYMASK=":$resrange&!@H="
     else
-      HEAVYMASK="$HEAVYMASK,:$resrange&!@H="
+      HEAVYMASK="$HEAVYMASK|:$resrange&!@H="
     fi
     if [ -z "$BACKBONEMASK" ] ; then
       BACKBONEMASK=":$resrange$bbatoms"
     else
-      BACKBONEMASK="$BACKBONEMASK,:$resrange$bbatoms"
+      BACKBONEMASK="$BACKBONEMASK|:$resrange$bbatoms"
     fi
   fi
 done < $TMPMASK

--- a/AmberMdPrep.sh
+++ b/AmberMdPrep.sh
@@ -6,7 +6,7 @@
 # NIH/NHLBI
 # 2020-08-07
 
-VERSION='0.6 (beta)'
+VERSION='0.7 (beta)'
 MPIRUN=`which mpirun`
 CPPTRAJ=`which cpptraj`
 

--- a/test/modified.residues/Save/step1.in
+++ b/test/modified.residues/Save/step1.in
@@ -3,5 +3,5 @@ Minimization: step1.in
    imin = 1, ntmin = 2, maxcyc = 1000, ncyc = 10,
    ntwx = 500, ioutfm = 1, ntxo = 2, ntpr = 50, ntwr = 500, 
    ntc = 1, ntf = 1, ntb = 1, cut = 8.0, 
-   ntr = 1, restraintmask = ":1-5&!@H=,:8-13&!@H=", restraint_wt = 5.0,
+   ntr = 1, restraintmask = ":1-5&!@H=|:8-13&!@H=", restraint_wt = 5.0,
  &end

--- a/test/modified.residues/Save/step2.in
+++ b/test/modified.residues/Save/step2.in
@@ -6,5 +6,5 @@ MD: step2.in
    iwrap = 0, nscm = 0,
    ntc = 2, ntf = 2, ntb = 1, cut = 8.0,  
    ntt = 3, gamma_ln = 5, temp0 = 300, tempi = 300,
-   ntr = 1, restraintmask = ":1-5&!@H=,:8-13&!@H=", restraint_wt = 5.0,
+   ntr = 1, restraintmask = ":1-5&!@H=|:8-13&!@H=", restraint_wt = 5.0,
  &end

--- a/test/modified.residues/Save/step3.in
+++ b/test/modified.residues/Save/step3.in
@@ -3,5 +3,5 @@ Minimization: step3.in
    imin = 1, ntmin = 2, maxcyc = 1000, ncyc = 10,
    ntwx = 500, ioutfm = 1, ntxo = 2, ntpr = 50, ntwr = 500, 
    ntc = 1, ntf = 1, ntb = 1, cut = 8.0, 
-   ntr = 1, restraintmask = ":1-5&!@H=,:8-13&!@H=", restraint_wt = 2.0,
+   ntr = 1, restraintmask = ":1-5&!@H=|:8-13&!@H=", restraint_wt = 2.0,
  &end

--- a/test/modified.residues/Save/step4.in
+++ b/test/modified.residues/Save/step4.in
@@ -3,5 +3,5 @@ Minimization: step4.in
    imin = 1, ntmin = 2, maxcyc = 1000, ncyc = 10,
    ntwx = 500, ioutfm = 1, ntxo = 2, ntpr = 50, ntwr = 500, 
    ntc = 1, ntf = 1, ntb = 1, cut = 8.0, 
-   ntr = 1, restraintmask = ":1-5&!@H=,:8-13&!@H=", restraint_wt = 0.1,
+   ntr = 1, restraintmask = ":1-5&!@H=|:8-13&!@H=", restraint_wt = 0.1,
  &end

--- a/test/modified.residues/Save/step6.in
+++ b/test/modified.residues/Save/step6.in
@@ -7,5 +7,5 @@ MD: step6.in
    ntc = 2, ntf = 2, ntb = 2, cut = 8.0,  
    ntt = 3, gamma_ln = 5, temp0 = 300, tempi = 300,
    ntp = 1, barostat = 2, pres0 = 1.0, mcbarint = 100,
-   ntr = 1, restraintmask = ":1-5&!@H=,:8-13&!@H=", restraint_wt = 1.0,
+   ntr = 1, restraintmask = ":1-5&!@H=|:8-13&!@H=", restraint_wt = 1.0,
  &end

--- a/test/modified.residues/Save/step7.in
+++ b/test/modified.residues/Save/step7.in
@@ -7,5 +7,5 @@ MD: step7.in
    ntc = 2, ntf = 2, ntb = 2, cut = 8.0,  
    ntt = 3, gamma_ln = 5, temp0 = 300, tempi = 300,
    ntp = 1, barostat = 2, pres0 = 1.0, mcbarint = 100,
-   ntr = 1, restraintmask = ":1-5&!@H=,:8-13&!@H=", restraint_wt = 0.5,
+   ntr = 1, restraintmask = ":1-5&!@H=|:8-13&!@H=", restraint_wt = 0.5,
  &end

--- a/test/modified.residues/Save/step8.in
+++ b/test/modified.residues/Save/step8.in
@@ -7,5 +7,5 @@ MD: step8.in
    ntc = 2, ntf = 2, ntb = 2, cut = 8.0,  
    ntt = 3, gamma_ln = 5, temp0 = 300, tempi = 300,
    ntp = 1, barostat = 2, pres0 = 1.0, mcbarint = 100,
-   ntr = 1, restraintmask = ":1-5@H,N,CA,HA,C,O,:8-13@H,N,CA,HA,C,O", restraint_wt = 0.5,
+   ntr = 1, restraintmask = ":1-5@H,N,CA,HA,C,O|:8-13@H,N,CA,HA,C,O", restraint_wt = 0.5,
  &end

--- a/test/modified.residues/test.out.save
+++ b/test/modified.residues/test.out.save
@@ -6,8 +6,8 @@ AmberMdPrep.sh Version 0.6 (beta)
 Warning: Unknown residues detected; will be ignored for restraints.
   Detected types :  protein
   NUM SOLUTE RES : 11
-  HEAVY MASK     : :1-5&!@H=,:8-13&!@H=
-  BACKBONE MASK  : :1-5@H,N,CA,HA,C,O,:8-13@H,N,CA,HA,C,O
+  HEAVY MASK     : :1-5&!@H=|:8-13&!@H=
+  BACKBONE MASK  : :1-5@H,N,CA,HA,C,O|:8-13@H,N,CA,HA,C,O
   TEMPERATURE    : 300
   OVERWRITE      : 0
   MD COMMAND     : pmemd


### PR DESCRIPTION
V0.7b.

Need to separate multiple ranges with `|` (or) instead of comma.